### PR TITLE
Added ability to mention item type

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Supported Options:
   * `total` - The total number of operations that _YOUR_ script will execute.
   * `maxBurden` - The maximum 'burden' that the progress bar should incur. See more about burden below.
   * `showBurden` - Mostly for debugging.  Show the current burden / skipped steps with the other metrics.
+  * `itemType` - The type of item being processed, e.g. 'widgets'.
 
 ### pace.op([count]) ###
 Signal to pace that an operation was completed in your script by calling

--- a/pace.js
+++ b/pace.js
@@ -44,7 +44,7 @@ function Pace(options) {
   // Whether to show current burden %.
   this.show_burden = options.showBurden || false;
   
-  // Type of item, e.g. 'widgets'
+  // Type of item, e.g. 'widgets'.
   this.itemType = options.itemType || '';
 
   // Internal time tracking properties.

--- a/pace.js
+++ b/pace.js
@@ -43,6 +43,9 @@ function Pace(options) {
 
   // Whether to show current burden %.
   this.show_burden = options.showBurden || false;
+  
+  // Type of item, e.g. 'widgets'
+  this.itemType = options.itemType || '';
 
   // Internal time tracking properties.
   this.started = false;
@@ -173,7 +176,7 @@ Pace.prototype.outputStats = function outputStats() {
   this.charm.write('            ').display('bright').write(this.perc + '%').display('reset');
   this.total_len = formatNumber(this.total).length;
   this.charm.write('   ').display('bright').write(padLeft(formatNumber(this.current), this.total_len)).display('reset');
-  this.charm.write('/' + formatNumber(this.total));
+  this.charm.write('/' + formatNumber(this.total) + ' ' + this.itemType);
 
   // Output burden.
   if (this.show_burden) {


### PR DESCRIPTION
For example, this:

```
var pace = require('pace')({
    total: 6838,
    itemType: 'points'
});
```

will result in this:
![screen shot 2013-08-30 at 5 30 04 pm](https://f.cloud.github.com/assets/370976/1060850/7c1b676c-11bc-11e3-9899-38d52047cd5d.png)
